### PR TITLE
quick-n-dirty implementation for loadtesting against momento objectstore

### DIFF
--- a/configs/momento_objectstore.toml
+++ b/configs/momento_objectstore.toml
@@ -1,0 +1,89 @@
+# Configuration for benchmarking Momento ObjectStore HTTP API
+#
+# API format:
+#   PUT /objectstore/{store_name}/{key}?ttl_seconds=N
+#   GET /objectstore/{store_name}/{key}
+#
+# Environment variable required:
+#   MOMENTO_API_KEY - Your Momento API key for authorization
+
+[general]
+# specify the protocol to be used
+protocol = "momento_objectstore"
+# the interval for stats integration and reporting
+interval = 5
+# the number of intervals to run the test for
+duration = 300
+# run the admin thread with a HTTP listener at the address provided, this allows
+# stats exposition via HTTP
+admin = "127.0.0.1:9090"
+# optionally, set an initial seed for the PRNGs used to generate the workload.
+# The default is to intialize from the OS entropy pool.
+initial_seed = "0"
+
+#[metrics]
+# output file for detailed stats during the run
+#output = "stats.json"
+# format of the output file (possible values are json, msgpack, parquet)
+#format = "json"
+# optionally specify batch size for parquet row groups
+# only valid for parquet output
+#batch_size = 100_000
+# optionally specify histogram type (can be standard (default) or sparse)
+# only valid for parquet output
+#histogram = "sparse"
+# optionally, specify the sampling interval for metrics. Input is a string
+# with the unit attached; for example "100ms" or "1s". Defaults to 1s.
+#interval = "1s"
+
+[debug]
+# choose from: error, warn, info, debug, trace
+log_level = "info"
+# optionally, log to the file below instead of standard out
+# log_file = "rpc-perf.log"
+# backup file name for use with log rotation
+log_backup = "rpc-perf.log.old"
+# trigger log rotation when the file grows beyond this size (in bytes). Set this
+# option to '0' to disable log rotation.
+log_max_size = 1073741824
+
+[target]
+# Momento ObjectStore HTTP API endpoint
+endpoints = ["https://api.cache.developer-vir-dev.preprod.a.momentohq.com"]
+# specify the name of the target object store
+object_store_name = "vir-object-store"
+
+[storage]
+# number of threads used to drive requests
+threads = 4
+# number of HTTP/2 connections to initialize
+poolsize = 4
+# number of concurrent requests per connection (HTTP/2 muxing)
+concurrency = 128
+# request timeout in milliseconds (currently informational)
+request_timeout = 5000
+
+[workload]
+# the number of threads that will be used to generate the workload
+threads = 1
+
+[workload.ratelimit]
+# set a global ratelimit for the workload (requests per second)
+start = 2
+
+# Object keyspace configuration
+[[workload.stores]]
+# object key length, in bytes
+klen = 32
+# sets the number of objects that will be generated
+nkeys = 1000
+# sets the object size, in bytes (max 20 MiB = 20971520 for objectstore)
+vlen = 20_048_576
+ttl = "1h"
+# controls what commands will be used
+commands = [
+    # GET /objectstore/{store}/{key}
+    { verb = "get", weight = 0 },
+    # PUT /objectstore/{store}/{key}?ttl_seconds=N
+    { verb = "put", weight = 100 },
+]

--- a/src/clients/store/mod.rs
+++ b/src/clients/store/mod.rs
@@ -12,6 +12,7 @@ use async_channel::Receiver;
 use tokio::runtime::Runtime;
 use workload::{ClientWorkItemKind, StoreClientRequest};
 
+mod momento_objectstore;
 mod s3;
 
 pub fn launch(
@@ -35,6 +36,9 @@ pub fn launch(
 
     match config.general().protocol() {
         Protocol::S3 => s3::launch_tasks(&mut client_rt, config.clone(), work_receiver),
+        Protocol::MomentoObjectstore => {
+            momento_objectstore::launch_tasks(&mut client_rt, config.clone(), work_receiver)
+        }
         protocol => {
             eprintln!(
                 "store commands are not supported for the {:?} protocol",

--- a/src/clients/store/momento_objectstore/mod.rs
+++ b/src/clients/store/momento_objectstore/mod.rs
@@ -1,0 +1,492 @@
+use crate::clients::common::*;
+use crate::workload::{ClientWorkItemKind, StoreClientRequest};
+use crate::*;
+use rustls::KeyLogFile;
+
+use async_channel::Receiver;
+use bytes::{Bytes, BytesMut};
+use h2::client::SendRequest;
+use http::{Method, Version};
+use rustls::pki_types::ServerName;
+use rustls::RootCertStore;
+use tokio::net::TcpStream;
+use tokio::runtime::Runtime;
+use tokio_rustls::TlsConnector;
+
+use std::time::{Duration, Instant};
+
+const MB: u32 = 1024 * 1024;
+
+pub fn launch_tasks(
+    runtime: &mut Runtime,
+    config: Config,
+    work_receiver: Receiver<ClientWorkItemKind<StoreClientRequest>>,
+) {
+    debug!("launching momento objectstore protocol tasks");
+
+    for _ in 0..config.storage().unwrap().poolsize() {
+        for endpoint in config.target().endpoints() {
+            let queue = Queue::new(1);
+            runtime.spawn(pool_manager(
+                endpoint.clone(),
+                config.clone(),
+                queue.clone(),
+            ));
+
+            for _ in 0..config.storage().unwrap().concurrency() {
+                runtime.spawn(task(
+                    work_receiver.clone(),
+                    endpoint.clone(),
+                    config.clone(),
+                    queue.clone(),
+                ));
+            }
+        }
+    }
+}
+
+pub async fn pool_manager(endpoint: String, _config: Config, queue: Queue<SendRequest<Bytes>>) {
+    let mut client = None;
+
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    config.key_log = Arc::new(KeyLogFile::new());
+
+    let config = Arc::new(config);
+
+    while RUNNING.load(Ordering::Relaxed) {
+        if client.is_none() {
+            CONNECT.increment();
+
+            if let Ok((addr, auth)) = resolve(&endpoint).await {
+                if let Ok(tcp) = TcpStream::connect(addr).await {
+                    if tcp.set_nodelay(true).is_err() {
+                        continue;
+                    }
+
+                    let connector: TlsConnector = TlsConnector::from(config.clone());
+                    let stream = match connector
+                        .connect(ServerName::try_from(auth.host().to_string()).unwrap(), tcp)
+                        .await
+                    {
+                        Ok(s) => s,
+                        Err(_) => {
+                            CONNECT_EX.increment();
+                            continue;
+                        }
+                    };
+
+                    let client_builder = ::h2::client::Builder::new()
+                        .initial_window_size(8 * MB)
+                        .initial_connection_window_size(8 * MB)
+                        .max_frame_size(2 * MB)
+                        .handshake(stream);
+
+                    if let Ok((h2, connection)) = client_builder.await {
+                        tokio::spawn(async move {
+                            let _ = connection.await;
+                        });
+
+                        if let Ok(h2) = h2.ready().await {
+                            CONNECT_OK.increment();
+                            CONNECT_CURR.increment();
+
+                            client = Some(h2);
+
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            CONNECT_EX.increment();
+        } else if let Ok(s) = client.clone().unwrap().ready().await {
+            let _ = queue.send(s).await;
+        } else {
+            client = None;
+        }
+    }
+}
+
+#[allow(clippy::slow_vector_initialization)]
+async fn task(
+    work_receiver: Receiver<ClientWorkItemKind<StoreClientRequest>>,
+    endpoint: String,
+    config: Config,
+    queue: Queue<SendRequest<Bytes>>,
+) -> Result<(), std::io::Error> {
+    let token = std::env::var("MOMENTO_API_KEY").unwrap_or_else(|_| {
+        eprintln!("environment variable `MOMENTO_API_KEY` is not set");
+        std::process::exit(1);
+    });
+
+    let store_name = config.target().object_store_name().unwrap_or_else(|| {
+        eprintln!("object_store_name is not specified in the `target` section");
+        std::process::exit(1);
+    });
+
+    let uri = endpoint.parse::<http::Uri>().unwrap_or_else(|e| {
+        eprintln!("target endpoint could not be parsed as a uri: {endpoint}\n{e}");
+        std::process::exit(1);
+    });
+
+    let endpoint = uri
+        .authority()
+        .unwrap_or_else(|| {
+            eprintln!("endpoint uri is missing an authority: {endpoint}");
+            std::process::exit(1);
+        })
+        .as_str()
+        .to_owned();
+
+    let mut buffer = BytesMut::new();
+
+    while RUNNING.load(Ordering::Relaxed) {
+        let sender = queue.recv().await;
+
+        if sender.is_err() {
+            continue;
+        }
+
+        let mut sender = sender.unwrap();
+
+        let work_item = match work_receiver.recv().await {
+            Ok(w) => w,
+            Err(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "channel closed",
+                ));
+            }
+        };
+
+        REQUEST.increment();
+
+        match &work_item {
+            ClientWorkItemKind::Request { request, .. } => match request {
+                StoreClientRequest::Get(r) => {
+                    let request = ObjectStoreRequestBuilder::get(
+                        &endpoint,
+                        store_name,
+                        &r.key,
+                    )
+                    .build(&token);
+
+                    let start = Instant::now();
+
+                    match sender.send_request(request, true) {
+                        Ok((response, _)) => {
+                            let response = response.await;
+
+                            let mut response = match response {
+                                Ok(r) => r,
+                                Err(_e) => {
+                                    STORE_GET_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                    continue;
+                                }
+                            };
+
+                            let ttfb = start.elapsed();
+                            let status = response.status().as_u16();
+
+                            buffer.truncate(0);
+
+                            let body = response.body_mut();
+
+                            if !body.is_end_stream() {
+                                let mut flow_control = body.flow_control().clone();
+
+                                let used = flow_control.used_capacity();
+                                if flow_control.release_capacity(used).is_err() {
+                                    STORE_GET_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                    continue;
+                                }
+
+                                while let Some(chunk) = body.data().await {
+                                    if chunk.is_err() {
+                                        STORE_GET_EX.increment();
+                                        STORE_RESPONSE_EX.increment();
+                                        continue;
+                                    }
+
+                                    let _ = flow_control.release_capacity(chunk.unwrap().len());
+                                }
+                            }
+
+                            let latency = start.elapsed();
+
+                            STORE_REQUEST_OK.increment();
+
+                            match status {
+                                200 => {
+                                    STORE_GET_OK.increment();
+                                    STORE_GET_KEY_FOUND.increment();
+                                    STORE_RESPONSE_OK.increment();
+                                    STORE_RESPONSE_FOUND.increment();
+
+                                    let _ = STORE_RESPONSE_LATENCY.increment(latency.as_nanos() as _);
+                                    let _ = STORE_RESPONSE_TTFB.increment(ttfb.as_nanos() as _);
+                                }
+                                404 => {
+                                    STORE_GET_OK.increment();
+                                    STORE_GET_KEY_NOT_FOUND.increment();
+                                    STORE_RESPONSE_OK.increment();
+                                    STORE_RESPONSE_NOT_FOUND.increment();
+
+                                    let _ = STORE_RESPONSE_LATENCY.increment(latency.as_nanos() as _);
+                                    let _ = STORE_RESPONSE_TTFB.increment(ttfb.as_nanos() as _);
+                                }
+                                429 => {
+                                    STORE_GET_EX.increment();
+                                    STORE_RESPONSE_RATELIMITED.increment();
+                                }
+                                _ => {
+                                    STORE_GET_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            continue;
+                        }
+                    }
+                }
+                StoreClientRequest::Put(r) => {
+                    let ttl = r.ttl.unwrap_or_else(|| Duration::from_secs(3600));
+
+                    let request = ObjectStoreRequestBuilder::put(
+                        &endpoint,
+                        store_name,
+                        &r.key,
+                        ttl,
+                    )
+                    .build(&token);
+
+                    let start = Instant::now();
+
+                    if let Ok((response, mut stream)) = sender.send_request(request, false) {
+                        let value = &r.value;
+
+                        let mut idx = 0;
+
+                        while idx < value.len() {
+                            stream.reserve_capacity(value.len() - idx);
+                            let mut available = stream.capacity();
+
+                            if available == 0 {
+                                available = 16384;
+                            }
+
+                            let end = idx + available;
+
+                            if end >= value.len() {
+                                stream
+                                    .send_data(value.slice(idx..value.len()), true)
+                                    .unwrap();
+                                break;
+                            } else {
+                                stream.send_data(value.slice(idx..end), false).unwrap();
+                                idx = end;
+                            }
+                        }
+
+                        if value.is_empty() {
+                            stream.send_data(Bytes::new(), true).unwrap();
+                        }
+
+                        stream.reserve_capacity(1024);
+
+                        let response = response.await;
+
+                        if response.is_err() {
+                            STORE_PUT_EX.increment();
+                            STORE_RESPONSE_EX.increment();
+                            continue;
+                        }
+
+                        let ttfb = start.elapsed();
+
+                        let mut response = response.unwrap();
+                        let body = response.body_mut();
+
+                        if !body.is_end_stream() {
+                            let mut flow_control = body.flow_control().clone();
+
+                            while let Some(chunk) = body.data().await {
+                                if chunk.is_err() {
+                                    STORE_PUT_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                    continue;
+                                }
+
+                                let _ = flow_control.release_capacity(chunk.unwrap().len());
+                            }
+                        };
+
+                        let status = response.status().as_u16();
+
+                        let latency = start.elapsed();
+
+                        STORE_REQUEST_OK.increment();
+
+                        match status {
+                            204 => {
+                                STORE_PUT_OK.increment();
+                                STORE_PUT_STORED.increment();
+                                STORE_RESPONSE_OK.increment();
+
+                                let _ = STORE_RESPONSE_LATENCY.increment(latency.as_nanos() as _);
+                                let _ = STORE_RESPONSE_TTFB.increment(ttfb.as_nanos() as _);
+                            }
+                            429 => {
+                                STORE_PUT_EX.increment();
+                                STORE_RESPONSE_RATELIMITED.increment();
+                            }
+                            _ => {
+                                STORE_PUT_EX.increment();
+                                STORE_RESPONSE_EX.increment();
+                            }
+                        }
+                    }
+                }
+                StoreClientRequest::Delete(r) => {
+                    let request = ObjectStoreRequestBuilder::delete(
+                        &endpoint,
+                        store_name,
+                        &r.key,
+                    )
+                    .build(&token);
+
+                    let start = Instant::now();
+
+                    match sender.send_request(request, true) {
+                        Ok((response, _)) => {
+                            let response = response.await;
+
+                            let mut response = match response {
+                                Ok(r) => r,
+                                Err(_e) => {
+                                    STORE_DELETE_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                    continue;
+                                }
+                            };
+
+                            let ttfb = start.elapsed();
+                            let status = response.status().as_u16();
+
+                            buffer.truncate(0);
+
+                            let body = response.body_mut();
+
+                            if !body.is_end_stream() {
+                                let mut flow_control = body.flow_control().clone();
+
+                                let used = flow_control.used_capacity();
+                                if flow_control.release_capacity(used).is_err() {
+                                    STORE_DELETE_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                    continue;
+                                }
+
+                                while let Some(chunk) = body.data().await {
+                                    if chunk.is_err() {
+                                        STORE_DELETE_EX.increment();
+                                        STORE_RESPONSE_EX.increment();
+                                        continue;
+                                    }
+
+                                    let _ = flow_control.release_capacity(chunk.unwrap().len());
+                                }
+                            }
+
+                            let latency = start.elapsed();
+
+                            STORE_REQUEST_OK.increment();
+
+                            match status {
+                                204 => {
+                                    STORE_DELETE_OK.increment();
+                                    STORE_RESPONSE_OK.increment();
+
+                                    let _ = STORE_RESPONSE_LATENCY.increment(latency.as_nanos() as _);
+                                    let _ = STORE_RESPONSE_TTFB.increment(ttfb.as_nanos() as _);
+                                }
+                                404 => {
+                                    STORE_DELETE_OK.increment();
+                                    STORE_RESPONSE_OK.increment();
+
+                                    let _ = STORE_RESPONSE_LATENCY.increment(latency.as_nanos() as _);
+                                    let _ = STORE_RESPONSE_TTFB.increment(ttfb.as_nanos() as _);
+                                }
+                                429 => {
+                                    STORE_DELETE_EX.increment();
+                                    STORE_RESPONSE_RATELIMITED.increment();
+                                }
+                                _ => {
+                                    STORE_DELETE_EX.increment();
+                                    STORE_RESPONSE_EX.increment();
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            continue;
+                        }
+                    }
+                }
+                _ => {
+                    REQUEST_UNSUPPORTED.increment();
+                    continue;
+                }
+            },
+            ClientWorkItemKind::Reconnect => {
+                REQUEST_UNSUPPORTED.increment();
+                continue;
+            }
+        };
+    }
+
+    Ok(())
+}
+
+pub struct ObjectStoreRequestBuilder {
+    inner: http::request::Builder,
+}
+
+impl ObjectStoreRequestBuilder {
+    fn new(endpoint: &str, method: Method, relative_uri: &str) -> Self {
+        let inner = http::request::Builder::new()
+            .version(Version::HTTP_2)
+            .method(method)
+            .uri(format!("https://{endpoint}{relative_uri}"));
+
+        Self { inner }
+    }
+
+    pub fn build(self, token: &str) -> http::Request<()> {
+        self.inner.header("authorization", token).body(()).unwrap()
+    }
+
+    pub fn delete(endpoint: &str, store: &str, key: &str) -> Self {
+        let uri = format!("/objectstore/{store}/{key}");
+        Self::new(endpoint, Method::DELETE, &uri)
+    }
+
+    pub fn get(endpoint: &str, store: &str, key: &str) -> Self {
+        let uri = format!("/objectstore/{store}/{key}");
+        Self::new(endpoint, Method::GET, &uri)
+    }
+
+    pub fn put(endpoint: &str, store: &str, key: &str, ttl: Duration) -> Self {
+        let uri = format!("/objectstore/{store}/{key}?ttl_seconds={}", ttl.as_secs());
+        Self::new(endpoint, Method::PUT, &uri)
+    }
+}

--- a/src/config/protocol.rs
+++ b/src/config/protocol.rs
@@ -7,6 +7,7 @@ pub enum Protocol {
     Memcache,
     Momento,
     MomentoHttp,
+    MomentoObjectstore,
     MomentoProtosocket,
     Mysql,
     Ping,

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -6,6 +6,12 @@ pub struct Storage {
     poolsize: usize,
     // number of threads for client tasks
     threads: usize,
+    #[serde(default = "default_concurrency")]
+    concurrency: usize,
+}
+
+fn default_concurrency() -> usize {
+    1
 }
 
 impl Storage {
@@ -15,5 +21,9 @@ impl Storage {
 
     pub fn poolsize(&self) -> usize {
         std::cmp::max(1, self.poolsize)
+    }
+
+    pub fn concurrency(&self) -> usize {
+        std::cmp::max(1, self.concurrency)
     }
 }

--- a/src/config/target.rs
+++ b/src/config/target.rs
@@ -6,6 +6,7 @@ pub struct Target {
     endpoints: Vec<String>,
     /// A cache name
     cache_name: Option<String>,
+    object_store_name: Option<String>,
     /// Manual endpoint override for protosocket clients
     endpoint_override: Option<String>,
     /// Configure protosocket clients to use private endpoints
@@ -19,6 +20,10 @@ impl Target {
 
     pub fn cache_name(&self) -> Option<&str> {
         self.cache_name.as_deref()
+    }
+
+    pub fn object_store_name(&self) -> Option<&str> {
+        self.object_store_name.as_deref()
     }
 
     pub fn endpoint_override(&self) -> Option<&str> {

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -74,6 +74,8 @@ pub struct Store {
     vkind: Option<ValueKind>,
     #[serde(default)]
     compression_ratio: Option<f64>,
+    #[serde(default)]
+    ttl: Option<String>,
 }
 
 impl Store {
@@ -107,6 +109,12 @@ impl Store {
 
     pub fn compression_ratio(&self) -> f64 {
         self.compression_ratio.unwrap_or(1.0)
+    }
+
+    pub fn ttl(&self) -> Option<Duration> {
+        self.ttl
+            .as_ref()
+            .map(|ttl| ttl.parse::<humantime::Duration>().unwrap().into())
     }
 }
 

--- a/src/workload/mod.rs
+++ b/src/workload/mod.rs
@@ -290,6 +290,7 @@ impl Generator {
             StoreVerb::Put => StoreClientRequest::Put(store::Put {
                 key: store.sample_string(rng),
                 value: store.gen_value(sequence as _, rng),
+                ttl: store.ttl(),
             }),
             StoreVerb::Get => StoreClientRequest::Get(store::Get {
                 key: store.sample_string(rng),
@@ -902,6 +903,7 @@ pub struct Store {
     vlen: usize,
     vkind: ValueKind,
     vbuf: Bytes,
+    ttl: Option<Duration>,
 }
 
 impl Store {
@@ -979,6 +981,7 @@ impl Store {
             vlen: store.vlen().unwrap_or(0),
             vkind: store.vkind(),
             vbuf: vbuf.into(),
+            ttl: store.ttl(),
         }
     }
 
@@ -1002,6 +1005,10 @@ impl Store {
                 self.vbuf.slice(start..end)
             }
         }
+    }
+
+    pub fn ttl(&self) -> Option<Duration> {
+        self.ttl
     }
 }
 

--- a/src/workload/store.rs
+++ b/src/workload/store.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Debug, PartialEq)]
 pub struct Get {
@@ -17,6 +18,7 @@ pub struct Put {
     /// a `String` type.
     pub key: Arc<String>,
     pub value: Bytes,
+    pub ttl: Option<Duration>,
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
There is a lot of copy-pasta between the new objectstore::task and the existing momentohttp::task.

Ideally they should share some common code; where the only behavior differences are how urls are constructed.